### PR TITLE
DeepL API translation support add

### DIFF
--- a/src/main/java/team/klover/server/global/security/config/SecurityConfig.java
+++ b/src/main/java/team/klover/server/global/security/config/SecurityConfig.java
@@ -59,6 +59,7 @@ public class SecurityConfig {
                                 "/api/v1/auth/line",
                                 "/api/v1/tour-post/**",
                                 "/api/v1/comm-post/**",
+                                "/api/v1/translate/**",
                                 // Swagger 관련 URL 추가
                                 "/v1/api-docs/**",
                                 "/swagger-ui/**").permitAll()

--- a/src/main/java/team/klover/server/global/security/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/team/klover/server/global/security/filter/JwtAuthorizationFilter.java
@@ -48,6 +48,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
                 || path.startsWith("/v1/api-docs")
                 || path.startsWith("/v1/api-docs/swagger-config")
                 || path.startsWith("/swagger-ui")
+                || path.startsWith("/api/v1/translate")
                 || (path.startsWith("/api/v1/comm-post/comment") && method.equals("GET"))
                 || (path.startsWith("/api/v1/comm-post/surroundings") && method.equals("GET"))
                 || (path.startsWith("/api/v1/comm-post/detail") && method.equals("GET"))

--- a/src/main/java/team/klover/server/global/translation/controller/ApiV1TranslateController.java
+++ b/src/main/java/team/klover/server/global/translation/controller/ApiV1TranslateController.java
@@ -1,0 +1,52 @@
+package team.klover.server.global.translation.controller;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.client.RestTemplate;
+import team.klover.server.global.translation.dto.req.TranslationRequest;
+import team.klover.server.global.translation.dto.res.TranslationResponse;
+
+import java.util.Collections;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+@RestController
+@RequestMapping(value = "/api/v1/translate",produces =APPLICATION_JSON_VALUE )
+@Tag(name = "ApiV1TranslateController",description = "Translate API")
+public class ApiV1TranslateController {
+
+    @Value("${translation.deepl.api-url}")
+    private String deeplApiUrl;
+
+    @Value("${translation.deepl.api-key}")
+    private String authKey;
+
+    @PostMapping
+    public ResponseEntity<TranslationResponse> translate(@RequestBody TranslationRequest request) {
+        String targetLang = request.getTarget_lang();
+
+        String apiUrl = deeplApiUrl + "?target_lang=" + targetLang;
+        RestTemplate restTemplate = new RestTemplate();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.add("Authorization", "DeepL-Auth-Key " + authKey);
+
+        TranslationResponse response = restTemplate.postForObject(apiUrl, createHttpEntity(request, headers), TranslationResponse.class);
+
+        return ResponseEntity.ok(response);
+    }
+
+    private HttpEntity<TranslationRequest> createHttpEntity(TranslationRequest request, HttpHeaders headers) {
+        return new HttpEntity<>(request, headers);
+    }
+}

--- a/src/main/java/team/klover/server/global/translation/dto/req/TranslationRequest.java
+++ b/src/main/java/team/klover/server/global/translation/dto/req/TranslationRequest.java
@@ -1,0 +1,13 @@
+package team.klover.server.global.translation.dto.req;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class TranslationRequest {
+    private List<String> text;
+    private String target_lang;
+}

--- a/src/main/java/team/klover/server/global/translation/dto/res/Translation.java
+++ b/src/main/java/team/klover/server/global/translation/dto/res/Translation.java
@@ -1,0 +1,11 @@
+package team.klover.server.global.translation.dto.res;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class Translation {
+    private String detected_source_language;
+    private String text;
+}

--- a/src/main/java/team/klover/server/global/translation/dto/res/TranslationResponse.java
+++ b/src/main/java/team/klover/server/global/translation/dto/res/TranslationResponse.java
@@ -1,0 +1,12 @@
+package team.klover.server.global.translation.dto.res;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class TranslationResponse {
+    private List<Translation> translations;
+}


### PR DESCRIPTION
## DeepL API 번역 지원 기능 추가

### 기능 설명
- DeepL API를 통한 다국어 번역 지원
- 커뮤니티, 채팅, 알림 메시지 번역 기능 구현

### 주요 변경 사항
- `ApiV1TranslateController` 생성
- `TranslationRequest`, `TranslationResponse` DTO 추가
- 여러 텍스트 동시 번역 지원
- DeepL API 인증 및 호출 로직 구현

### 구현 Details
- 목표 언어 설정 가능
- 다중 메시지 번역 지원
- RestTemplate을 사용한 API 호출

### 테스트 방법
1. Postman 또는 swagger를 통해 API 엔드포인트 테스트
2. 다양한 언어와 메시지 길이로 번역 기능 검증

### 추가 고려사항
- 향후 오류 핸들링 개선 필요
- 캐싱 메커니즘 고려 가능